### PR TITLE
Fix rc_add to inform user based on detected rc file

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -5,7 +5,7 @@ rm -rf $ROOT_DIR
 
 rc_add() {
   name=$1
-  echo ".bashrc detected. updating \033[1;33mPATH\033[0m variable and exporting it through $HOME/$name"
+  echo "$name detected. updating \033[1;33mPATH\033[0m variable and exporting it in $HOME/$name"
   echo "export PATH=$PATH:$HOME/.py-prompts" >> $HOME/$name
   echo "\033[1;33mpy-prompts\033[0m is now installed on your machine."
 }
@@ -29,7 +29,7 @@ elif [ -f $HOME/.zshrc ]; then
   fi
 else
   echo ""
-  echo "\033[0;31mCould not detect your rc file. kindly add the following line in your rc file.\033[0m"
+  echo "\033[0;31mCould not detect your rc file. Kindly add the following line in your rc file.\033[0m"
   echo ""
   echo "\033[0;34mexport PATH=$PATH:$HOME/.py-prompts\033[0m"
 fi

--- a/py-prompts
+++ b/py-prompts
@@ -49,7 +49,7 @@ if [ "$command" = "set" ]; then
     elif [ -f $HOME/.zshrc ]; then
       echo "export PYTHONSTARTUP=$HOME/.py-prompts/themes/$theme_name.py" >> $HOME/.zshrc
     else
-      echo "\033[0;31mCould not detect your rc file. kindly add the following line in your rc file.\033[0m"
+      echo "\033[0;31mCould not detect your rc file. Kindly add the following line in your rc file.\033[0m"
       echo "\033[0;34mexport PYTHONSTARTUP=$HOME/.py-prompts/themes/$theme_name.py\033[0m"
     fi
   fi


### PR DESCRIPTION
Previously, this was hard coded to always say .bashrc, even if only a .zshrc was detected.